### PR TITLE
change dispatch pipeline

### DIFF
--- a/examples/register_and_change_username.php
+++ b/examples/register_and_change_username.php
@@ -47,43 +47,32 @@ $commandMap = [
 $dispatch = Kernel\buildCommandDispatcher(
     $commandMap,
     $factories['eventStore'],
-    $factories['dummyProducer'],
     $factories['snapshotStore']
 );
 
-// uncomment to enable amqp publisher
-//$dispatch = Kernel\buildCommandDispatcher(
-//    $commandMap,
-//    $factories['eventStore'],
-//    $factories['amqpProducer'],
-//    $factories['snapshotStore'],
-//    $factories['startAmqpTransaction'],
-//    $factories['commitAmqpTransaction']
-//);
-
 $command = new RegisterUser(['id' => '1', 'name' => 'Alex', 'email' => 'member@getprooph.org']);
 
-$state = $dispatch($command);
+$aggregateResult = $dispatch($command);
 
 echo "User was registered: \n";
-echo json_encode($state) . "\n\n";
+echo json_encode($aggregateResult->state()) . "\n\n";
 
-$state = $dispatch(new ChangeUserName(['id' => '1', 'name' => 'Sascha']));
+$aggregateResult = $dispatch(new ChangeUserName(['id' => '1', 'name' => 'Sascha']));
 
 echo "Username changed: \n";
-echo json_encode($state) . "\n\n";
+echo json_encode($aggregateResult->state()) . "\n\n";
 
 // should return a TypeError
-$state = $dispatch(new InvalidCommand());
+$throwable = $dispatch(new InvalidCommand());
 
-echo get_class($state) . "\n";
-echo $state->getMessage() . "\n\n";
+echo get_class($throwable) . "\n";
+echo $throwable->getMessage() . "\n\n";
 
-$state = $dispatch(new UnknownCommand());
+$throwable = $dispatch(new UnknownCommand());
 
 // should return a RuntimeException
-echo get_class($state) . "\n";
-echo $state->getMessage() . "\n\n";
+echo get_class($throwable) . "\n";
+echo $throwable->getMessage() . "\n\n";
 
 $time = microtime(true) - $start;
 

--- a/src/AggregateResult.php
+++ b/src/AggregateResult.php
@@ -17,8 +17,14 @@ use Prooph\Common\Messaging\Message;
 
 final class AggregateResult
 {
+    /**
+     * @var Message[]
+     */
     private $raisedEvents;
 
+    /**
+     * @var array
+     */
     private $state;
 
     public function __construct(array $state, Message ...$raisedEvents)


### PR DESCRIPTION
- return aggregate result instead of state
- remove publishing from the pipeline (should be a user task)
- remove amqp factories

Question:
- Should we also remove the AmqpPublisher from this repository? Otherwise some day we have to maintain lot's of publishers in this repository. Also maybe you may want to use `Humus\Amqp`'s abstraction for amqp drivers. But I leave this for discussion.