### PR TITLE
updates test case to match new implementation

### DIFF
--- a/tests/Command/SetupCommandTest.php
+++ b/tests/Command/SetupCommandTest.php
@@ -129,7 +129,7 @@ final class SetupCommandTest extends TestCase
 
     private function prepareTempDirectory(): void
     {
-        if (!is_dir($this->getTempDirectory() . '/gateway')) {
+        if (! is_dir($this->getTempDirectory() . '/gateway')) {
             mkdir($this->getTempDirectory() . '/gateway', 0777, true);
         }
     }


### PR DESCRIPTION
Since all directories are always available, the test case for SetupCommand has to prepare all temporary directories by himself.

Also the input parameter for the gateway directory are removed.