### PR TITLE
add micro command for composer

### DIFF
--- a/bin/micro.php
+++ b/bin/micro.php
@@ -29,4 +29,5 @@ $application->add(new Command\SetupCommand());
 $application->add(new Command\CreateMySqlCommand());
 $application->add(new Command\CreatePostgresCommand());
 $application->add(new Command\CreatePhpServiceCommand());
+$application->add(new Command\ComposerInstallCommand());
 $application->run();

--- a/bin/micro.php
+++ b/bin/micro.php
@@ -30,4 +30,5 @@ $application->add(new Command\CreateMySqlCommand());
 $application->add(new Command\CreatePostgresCommand());
 $application->add(new Command\CreatePhpServiceCommand());
 $application->add(new Command\ComposerInstallCommand());
+$application->add(new Command\ComposerUpdateCommand());
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "symfony/console": "^3.2.2",
         "symfony/filesystem": "^3.2.2",
         "symfony/yaml": "^3.2.2",
+        "symfony/process": ">=2.4.0",
         "madkom/nginx-configurator": "dev-master",
         "ferno/loco": "dev-master"
     },

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -17,6 +17,11 @@ use Symfony\Component\Yaml\Yaml;
 
 abstract class AbstractCommand extends Command
 {
+    /*
+     * Defines the relative directory path where services are stored.
+     */
+    protected const SERVICE_DIR_PATH = './service';
+
     protected function getRootDir(): string
     {
         if (file_exists(__DIR__ . '/../../vendor/autoload.php')) {

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -17,11 +17,6 @@ use Symfony\Component\Yaml\Yaml;
 
 abstract class AbstractCommand extends Command
 {
-    /*
-     * Defines the relative directory path where services are stored.
-     */
-    protected const SERVICE_DIR_PATH = './service';
-
     protected function getRootDir(): string
     {
         if (file_exists(__DIR__ . '/../../vendor/autoload.php')) {
@@ -29,6 +24,11 @@ abstract class AbstractCommand extends Command
         } elseif (file_exists(__DIR__ . '/../../../../autoload.php')) {
             return realpath(__DIR__ . '/../../../../../');
         }
+    }
+
+    protected function getServiceDirPath($serviceName): string
+    {
+        return $this->getRootDir() . '/service/' . $serviceName;
     }
 
     protected function getDockerComposeConfig(): array

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -26,6 +26,14 @@ abstract class AbstractCommand extends Command
         }
     }
 
+    protected function getDockerComposeConfig(): array
+    {
+        $configFileName = $this->getRootDir() . '/docker-compose.yml';
+        $configFile = file_get_contents($configFileName);
+
+        return Yaml::parse($configFile);
+    }
+
     protected function updateConfig(string $serviceName, array $config): void
     {
         $configFileName = $this->getRootDir() . '/docker-compose.yml';

--- a/src/Command/AbstractComposerCommand.php
+++ b/src/Command/AbstractComposerCommand.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * This file is part of the prooph/micro.
+ * (c) 2017-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\Micro\Command;
+
+use Symfony\Component\Console\Helper\ProcessHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\OutputStyle;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\ProcessBuilder;
+
+abstract class AbstractComposerCommand extends AbstractCommand
+{
+    private const DEFAULT_TIMEOUT = 0;
+    private const DEFAULT_IDLE_TIMEOUT = 30;
+
+    abstract protected function getComposerCommand(): string;
+
+    protected function configure()
+    {
+        $this
+            ->addArgument('service', InputArgument::OPTIONAL)
+            ->addOption('all', '-a', InputOption::VALUE_NONE)
+            ->addOption(
+                'timeout',
+                '-t',
+                InputOption::VALUE_REQUIRED,
+                'Sets the process timeout (max. runtime) per service in seconds',
+                self::DEFAULT_TIMEOUT
+            )
+            ->addOption(
+                'idle-timeout',
+                '-i',
+                InputOption::VALUE_REQUIRED,
+                'Sets the process idle timeout (max. time since last output) per service in seconds',
+                self::DEFAULT_IDLE_TIMEOUT
+            )
+            ->addOption(
+                'docker-executable',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Sets the path to docker executable'
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $declaredPhpServices = $this->getDeclaredPhpServices();
+
+        if (! $declaredPhpServices) {
+            $io->warning('No php services declared in docker-compose.yml. Aborting');
+
+            return 1;
+        }
+
+        $requestedServices = $this->getRequestedServices($input, $io, $declaredPhpServices);
+
+        $timeout = (int) $input->getOption('timeout');
+        $idleTimeout = (int) $input->getOption('idle-timeout');
+        $dockerExecutable = $this->getDockerComposeExecutable($input);
+
+        $processBuilder = new ProcessBuilder();
+        $processBuilder->setPrefix($dockerExecutable);
+        $processBuilder->setTimeout($timeout);
+
+        /** @var ProcessHelper $processHelper */
+        $processHelper = $this->getHelper('process');
+
+        $command = $this->getComposerCommand();
+
+        foreach ($requestedServices as $service => $values) {
+            $io->newLine(2);
+            $io->section("Run `docker-compose $command` for service $service");
+
+            $processBuilder->setArguments([
+                'run',
+                '--rm',
+                '--env',
+                'COMPOSER_ALLOW_SUPERUSER=1',
+                '--volume',
+                $this->getServiceDirPath($service) . ':/app:rw',
+                'prooph/composer:'. $values['php_version'],
+                $command,
+                '--no-interaction',
+                '--no-suggest',
+            ]);
+
+            $process = $processBuilder->getProcess();
+            $process->setIdleTimeout($idleTimeout);
+
+            $processHelper->mustRun($output, $process, null, function ($type, $buffer) use ($io) {
+                $io->write("$buffer");
+            });
+        }
+
+        return 0;
+    }
+
+    private function getDeclaredPhpServices(): array
+    {
+        $phpServices = [];
+        $dockerComposeConfig = $this->getDockerComposeConfig();
+
+        foreach ($dockerComposeConfig['services'] as $service => $serviceConfig) {
+            if (! isset($serviceConfig['image'])) {
+                continue;
+            }
+
+            if (! preg_match('/^prooph\/php:([0-9\.]+)/', $serviceConfig['image'], $phpVersionMatches)) {
+                continue;
+            }
+
+            if (! file_exists($this->getServiceDirPath($service) . '/composer.json')) {
+                continue;
+            }
+
+            $phpServices[$service] = [
+                'php_version' => $phpVersionMatches[1],
+            ];
+        }
+
+        return $phpServices;
+    }
+
+    private function getRequestedServices(InputInterface $input, OutputStyle $io, array $requestedServices): array
+    {
+        if ($input->getOption('all')) {
+            return $requestedServices;
+        }
+
+        $requestedService = $input->getArgument('service');
+
+        if ($requestedService && ! array_key_exists($requestedService, $requestedServices)) {
+            $io->warning("Service with name '$requestedService' is not configured in docker-compose.yml yet.");
+            $requestedService = null;
+        }
+
+        if (! $requestedService) {
+            $requestedService = $io->choice('Select a service', array_keys($requestedServices));
+        }
+
+        if (! array_key_exists($requestedService, $requestedServices)) {
+            throw new \RuntimeException('Invalid service name provided.');
+        }
+
+        return [$requestedService => $requestedServices[$requestedService]];
+    }
+
+    private function getDockerComposeExecutable(InputInterface $input): string
+    {
+        static $executableFinder = null;
+
+        $dockerExecutable = $input->getOption('docker-executable');
+
+        if (null !== $dockerExecutable) {
+            return $dockerExecutable;
+        }
+
+        if (null === $executableFinder) {
+            $executableFinder = new ExecutableFinder();
+        }
+
+        $dockerComposePath = $executableFinder->find('docker', null);
+
+        if (null === $dockerComposePath) {
+            throw new \RuntimeException(
+                'Could not detect docker executable. Please provide it with --docker-executable option.'
+            );
+        }
+
+        return $dockerComposePath;
+    }
+}

--- a/src/Command/AbstractComposerCommand.php
+++ b/src/Command/AbstractComposerCommand.php
@@ -53,8 +53,7 @@ abstract class AbstractComposerCommand extends AbstractCommand
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Sets the path to docker executable'
-            )
-        ;
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/ComposerInstallCommand.php
+++ b/src/Command/ComposerInstallCommand.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Prooph\Micro\Command;
 
-final class ComposerInstallCommand extends AbstractComposerCommand
+class ComposerInstallCommand extends AbstractComposerCommand
 {
     protected function getComposerCommand(): string
     {

--- a/src/Command/ComposerInstallCommand.php
+++ b/src/Command/ComposerInstallCommand.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Prooph\Micro\Command;
 
@@ -13,8 +15,7 @@ final class ComposerInstallCommand extends AbstractComposerCommand
     {
         $this
             ->setName('micro:composer:install')
-            ->setDescription('Installs composer dependencies for services')
-        ;
+            ->setDescription('Installs composer dependencies for services');
 
         parent::configure();
     }

--- a/src/Command/ComposerInstallCommand.php
+++ b/src/Command/ComposerInstallCommand.php
@@ -82,8 +82,6 @@ final class ComposerInstallCommand extends AbstractCommand
         /** @var ProcessHelper $processHelper */
         $processHelper = $this->getHelper('process');
 
-        $serviceDirPath = $this->getRootDir() . '/' . self::SERVICE_DIR_PATH;
-
         foreach ($requestedServices as $service => $values) {
             $io->newLine(2);
             $io->section("Run `docker-compose install` for service $service");
@@ -95,7 +93,7 @@ final class ComposerInstallCommand extends AbstractCommand
                 '-e',
                 'COMPOSER_ALLOW_SUPERUSER=1',
                 '--volume',
-                sprintf('%s/%s:/app:rw', $serviceDirPath, $service),
+                $this->getServiceDirPath($service) . ':/app:rw',
                 'prooph/composer:'. $values['php_version'],
                 'install',
                 '--no-interaction',
@@ -124,6 +122,10 @@ final class ComposerInstallCommand extends AbstractCommand
             }
 
             if (! preg_match('/^prooph\/php:([0-9\.]+)/', $serviceConfig['image'], $phpVersionMatches)) {
+                continue;
+            }
+
+            if (! file_exists($this->getServiceDirPath($service) . '/composer.json')) {
                 continue;
             }
 

--- a/src/Command/ComposerInstallCommand.php
+++ b/src/Command/ComposerInstallCommand.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * This file is part of the prooph/micro.
+ * (c) 2017-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 declare(strict_types=1);
 

--- a/src/Command/ComposerInstallCommand.php
+++ b/src/Command/ComposerInstallCommand.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This file is part of the prooph/micro.
+ * (c) 2017-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\Micro\Command;
+
+use Symfony\Component\Console\Helper\ProcessHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\ProcessBuilder;
+
+final class ComposerInstallCommand extends AbstractCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('micro:composer:install')
+            ->setDescription('Install composer dependencies for services');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $dockerComposeConfig = $this->getDockerComposeConfig();
+        $phpServices = [];
+
+        foreach ($dockerComposeConfig['services'] as $service => $serviceConfig) {
+            if (isset($serviceConfig['image']) && preg_match('/^prooph\/php:([0-9\.]+)/', $serviceConfig['image'],
+                    $matches)
+            ) {
+                $phpServices[$service] = $matches[1];
+            }
+        }
+
+        $servicePath = $this->getRootDir() . '/service';
+
+        /** @var ProcessHelper $processHelper */
+        $processHelper = $this->getHelper('process');
+
+        foreach ($phpServices as $service => $phpVersion) {
+            $process = ProcessBuilder::create([
+                '/usr/local/bin/docker',
+                'run',
+                '--rm',
+                '-i',
+                '--volume',
+                "$servicePath/$service:/app",
+                '-e',
+                'COMPOSER_ALLOW_SUPERUSER=1',
+                "prooph/composer:$phpVersion",
+                'install',
+                '--no-interaction',
+                '--no-suggest',
+                '--optimize-autoloader',
+            ])
+                ->getProcess();
+
+            $process->setTimeout(0);
+            $process->setIdleTimeout(30);
+
+            $processHelper->run($output, $process);
+        }
+
+        return 0;
+    }
+}

--- a/src/Command/ComposerUpdateCommand.php
+++ b/src/Command/ComposerUpdateCommand.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Prooph\Micro\Command;
 
-final class ComposerUpdateCommand extends AbstractComposerCommand
+class ComposerUpdateCommand extends AbstractComposerCommand
 {
     protected function getComposerCommand(): string
     {

--- a/src/Command/ComposerUpdateCommand.php
+++ b/src/Command/ComposerUpdateCommand.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Prooph\Micro\Command;
 
@@ -13,8 +15,7 @@ final class ComposerUpdateCommand extends AbstractComposerCommand
     {
         $this
             ->setName('micro:composer:update')
-            ->setDescription('Updates composer dependencies for services')
-        ;
+            ->setDescription('Updates composer dependencies for services');
 
         parent::configure();
     }

--- a/src/Command/ComposerUpdateCommand.php
+++ b/src/Command/ComposerUpdateCommand.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * This file is part of the prooph/micro.
+ * (c) 2017-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 declare(strict_types=1);
 

--- a/src/Command/ComposerUpdateCommand.php
+++ b/src/Command/ComposerUpdateCommand.php
@@ -2,18 +2,18 @@
 
 namespace Prooph\Micro\Command;
 
-final class ComposerInstallCommand extends AbstractComposerCommand
+final class ComposerUpdateCommand extends AbstractComposerCommand
 {
     protected function getComposerCommand(): string
     {
-        return 'install';
+        return 'update';
     }
 
     protected function configure()
     {
         $this
-            ->setName('micro:composer:install')
-            ->setDescription('Installs composer dependencies for services')
+            ->setName('micro:composer:update')
+            ->setDescription('Updates composer dependencies for services')
         ;
 
         parent::configure();

--- a/tests/Command/ComposerCommandTestCase.php
+++ b/tests/Command/ComposerCommandTestCase.php
@@ -8,13 +8,13 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace ProophTest\Micro\Command;
 
 use PhpCsFixer\Console\Application;
-use Prooph\Micro\Command\AbstractComposerCommand;
 use PHPUnit\Framework\TestCase;
+use Prooph\Micro\Command\AbstractComposerCommand;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -73,7 +73,7 @@ abstract class ComposerCommandTestCase extends TestCase
      */
     public function it_aborts_if_no_php_service_is_declared(): void
     {
-        file_put_contents($this->getTempDirectory() . '/docker-compose.yml', "services: []");
+        file_put_contents($this->getTempDirectory() . '/docker-compose.yml', 'services: []');
 
         $commandTester = new CommandTester($this->command);
         $commandTester->execute([]);
@@ -108,7 +108,7 @@ EOL
 );
 
         $commandTester = new CommandTester($this->command);
-        $commandTester->setInputs([0]); # we choose the first service here
+        $commandTester->setInputs([0]); // we choose the first service here
         $commandTester->execute(['--docker-executable' => 'echo']);
 
         $display = $commandTester->getDisplay();
@@ -143,7 +143,7 @@ EOL
         $commandTester = new CommandTester($this->command);
         $commandTester->execute([
             'service' => 'php_service1',
-            '--docker-executable' => 'echo'
+            '--docker-executable' => 'echo',
         ]);
 
         $display = $commandTester->getDisplay();
@@ -174,7 +174,7 @@ EOL
         $commandTester->setInputs([0]);
         $commandTester->execute([
             'service' => 'not_a_service',
-            '--docker-executable' => 'echo'
+            '--docker-executable' => 'echo',
         ]);
 
         $display = $commandTester->getDisplay();
@@ -207,7 +207,7 @@ EOL
         $commandTester = new CommandTester($this->command);
         $commandTester->execute([
             '--all' => true,
-            '--docker-executable' => 'echo'
+            '--docker-executable' => 'echo',
         ]);
 
         $display = $commandTester->getDisplay();
@@ -246,18 +246,18 @@ EOL
 
     private function prepareTempDirectories(): void
     {
-        if (!is_dir($this->getTempDirectory())) {
+        if (! is_dir($this->getTempDirectory())) {
             mkdir($this->getTempDirectory(), 0777, true);
         }
 
-        if (!is_dir($this->getServiceDirectory())) {
+        if (! is_dir($this->getServiceDirectory())) {
             mkdir($this->getServiceDirectory(), 0777, true);
         }
     }
 
     private function prepareServiceComposerFile(string $serviceName): void
     {
-        if (!is_dir($this->getServiceDirectory() . '/' . $serviceName)) {
+        if (! is_dir($this->getServiceDirectory() . '/' . $serviceName)) {
             mkdir($this->getServiceDirectory() . '/' . $serviceName, 0777, true);
         }
 

--- a/tests/Command/ComposerCommandTestCase.php
+++ b/tests/Command/ComposerCommandTestCase.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * This file is part of the prooph/micro.
+ * (c) 2017-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace ProophTest\Micro\Command;
+
+use PhpCsFixer\Console\Application;
+use Prooph\Micro\Command\AbstractComposerCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @coversDefaultClass Prooph\Micro\Command\AbstractComposerCommand
+ */
+abstract class ComposerCommandTestCase extends TestCase
+{
+    /**
+     * @var AbstractComposerCommand
+     */
+    protected $command;
+
+    public function setUp(): void
+    {
+        $this->prepareTempDirectories();
+
+        /** @var AbstractComposerCommand $command */
+        $command = $this->getMockBuilder($this->getComposerCommandClass())
+            ->setMethods(['getRootDir', 'getServiceDirPath'])
+            ->getMock();
+
+        $command
+            ->method('getRootDir')
+            ->willReturn($this->getTempDirectory());
+
+        $command
+            ->method('getServiceDirPath')
+            ->will($this->returnCallback(function ($service) {
+                return $this->getServiceDirectory() . '/' . $service;
+            }));
+
+        $application = new Application();
+        $application->add($command);
+
+        $this->command = $application->get($command->getName());
+    }
+
+    public function tearDown(): void
+    {
+        $this->removeTempDirectory();
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function it_creates_command_instance(): void
+    {
+        $this->assertInstanceOf($this->getComposerCommandClass(), $this->command);
+    }
+
+    /**
+     * @test
+     * @covers ::execute
+     * @covers ::getDeclaredPhpServices
+     */
+    public function it_aborts_if_no_php_service_is_declared(): void
+    {
+        file_put_contents($this->getTempDirectory() . '/docker-compose.yml', "services: []");
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([]);
+
+        $this->assertSame(1, $commandTester->getStatusCode());
+        $this->assertContains('No php services declared in docker-compose.yml', $commandTester->getDisplay());
+    }
+
+    /**
+     * @test
+     * @covers ::execute
+     * @covers ::getDeclaredPhpServices
+     */
+    public function it_founds_declared_php_services_with_composer_file(): void
+    {
+        $this->prepareServiceComposerFile('php_service1');
+        $this->prepareServiceComposerFile('php_service2');
+
+        file_put_contents($this->getTempDirectory() . '/docker-compose.yml', <<<EOL
+services:
+    php_service1:
+        image: prooph/php:7.1
+    php_service2:
+        image: prooph/php:7.0.14
+    php_service_without_composer_file:
+        image: prooph/php:5.6
+    other_service:
+        image: fuubar
+    another_service:
+        build: .
+EOL
+);
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->setInputs([0]); # we choose the first service here
+        $commandTester->execute(['--docker-executable' => 'echo']);
+
+        $display = $commandTester->getDisplay();
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertContains('php_service1', $display);
+        $this->assertContains('php_service2', $display);
+        $this->assertNotContains('php_service_without_composer_file', $display);
+        $this->assertNotContains('other_service', $display);
+        $this->assertNotContains('another_service', $display);
+    }
+
+    /**
+     * @test
+     * @covers ::execute
+     * @covers ::getRequestedServices
+     */
+    public function it_selects_service_from_argument(): void
+    {
+        $this->prepareServiceComposerFile('php_service1');
+        $this->prepareServiceComposerFile('php_service2');
+
+        file_put_contents($this->getTempDirectory() . '/docker-compose.yml', <<<EOL
+services:
+    php_service1:
+        image: prooph/php:7.1
+    php_service2:
+        image: prooph/php:7.0.14
+EOL
+        );
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([
+            'service' => 'php_service1',
+            '--docker-executable' => 'echo'
+        ]);
+
+        $display = $commandTester->getDisplay();
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertContains('php_service1', $display);
+        $this->assertNotContains('Select a service', $display);
+        $this->assertNotContains('php_service2', $display);
+    }
+
+    /**
+     * @test
+     * @covers ::execute
+     * @covers ::getRequestedServices
+     */
+    public function it_requests_service_if_service_argument_is_not_valid(): void
+    {
+        $this->prepareServiceComposerFile('php_service1');
+
+        file_put_contents($this->getTempDirectory() . '/docker-compose.yml', <<<EOL
+services:
+    php_service1:
+        image: prooph/php:7.1
+EOL
+        );
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->setInputs([0]);
+        $commandTester->execute([
+            'service' => 'not_a_service',
+            '--docker-executable' => 'echo'
+        ]);
+
+        $display = $commandTester->getDisplay();
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertContains('php_service1', $display);
+        $this->assertContains('Select a service', $display);
+        $this->assertContains("Service with name 'not_a_service' is not configured", $display);
+    }
+
+    /**
+     * @test
+     * @covers ::execute
+     * @covers ::getRequestedServices
+     */
+    public function it_selects_all_services_with_option(): void
+    {
+        $this->prepareServiceComposerFile('php_service1');
+        $this->prepareServiceComposerFile('php_service2');
+
+        file_put_contents($this->getTempDirectory() . '/docker-compose.yml', <<<EOL
+services:
+    php_service1:
+        image: prooph/php:7.1
+    php_service2:
+        image: prooph/php:7.0.14
+EOL
+        );
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([
+            '--all' => true,
+            '--docker-executable' => 'echo'
+        ]);
+
+        $display = $commandTester->getDisplay();
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertContains('php_service1', $display);
+        $this->assertContains('php_service2', $display);
+        $this->assertNotContains('Select a service', $display);
+    }
+
+    abstract protected function getComposerCommandClass(): string;
+
+    private function getTempDirectory(): string
+    {
+        return sys_get_temp_dir() . '/prooph_test';
+    }
+
+    private function getServiceDirectory(): string
+    {
+        return $this->getTempDirectory() . '/services';
+    }
+
+    private function removeTempDirectory(): void
+    {
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->getTempDirectory(), \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $fileInfo) {
+            $fileInfo->isDir() ? rmdir($fileInfo->getRealPath()) : unlink($fileInfo->getRealPath());
+        }
+
+        rmdir($this->getTempDirectory());
+    }
+
+    private function prepareTempDirectories(): void
+    {
+        if (!is_dir($this->getTempDirectory())) {
+            mkdir($this->getTempDirectory(), 0777, true);
+        }
+
+        if (!is_dir($this->getServiceDirectory())) {
+            mkdir($this->getServiceDirectory(), 0777, true);
+        }
+    }
+
+    private function prepareServiceComposerFile(string $serviceName): void
+    {
+        if (!is_dir($this->getServiceDirectory() . '/' . $serviceName)) {
+            mkdir($this->getServiceDirectory() . '/' . $serviceName, 0777, true);
+        }
+
+        file_put_contents($this->getServiceDirectory() . '/' . $serviceName . '/composer.json', '{}');
+    }
+}

--- a/tests/Command/ComposerInstallCommandTest.php
+++ b/tests/Command/ComposerInstallCommandTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace ProophTest\Micro\Command;
 

--- a/tests/Command/ComposerInstallCommandTest.php
+++ b/tests/Command/ComposerInstallCommandTest.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * This file is part of the prooph/micro.
+ * (c) 2017-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 declare(strict_types=1);
 

--- a/tests/Command/ComposerInstallCommandTest.php
+++ b/tests/Command/ComposerInstallCommandTest.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace ProophTest\Micro\Command;
+
+use Prooph\Micro\Command\ComposerInstallCommand;
+
+/**
+ * @coversDefaultClass Prooph\Micro\Command\ComposerInstallCommand
+ */
+final class ComposerInstallCommandTest extends ComposerCommandTestCase
+{
+    protected function getComposerCommandClass(): string
+    {
+        return ComposerInstallCommand::class;
+    }
+}

--- a/tests/Command/ComposerUpdateCommandTest.php
+++ b/tests/Command/ComposerUpdateCommandTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace ProophTest\Micro\Command;
 

--- a/tests/Command/ComposerUpdateCommandTest.php
+++ b/tests/Command/ComposerUpdateCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the prooph/micro.
+ * (c) 2017-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace ProophTest\Micro\Command;
+
+use Prooph\Micro\Command\ComposerUpdateCommand;
+
+/**
+ * @coversDefaultClass Prooph\Micro\Command\ComposerUpdateCommand
+ */
+final class ComposerUpdateCommandTest extends ComposerCommandTestCase
+{
+    protected function getComposerCommandClass(): string
+    {
+        return ComposerUpdateCommand::class;
+    }
+}


### PR DESCRIPTION
This PR provides two new commands for composer install and composer update all php services and will resolve https://github.com/prooph/micro/issues/21.

**TODO**
- [x] find `docker` executable on default paths and request path if not
- ~optimize composer command and provide option to add parameters~
To add undefined options it is necessary to provide a service name. Maybe no more composer parameters are required. However they could defined for command if needed.
- [x] add options for timeouts
- [x] stop follow-up prozesses if one has failed
- [x] improve output
- ~configure cache and cert paths for composer~
Composers cache directory is shared by default on my machine. Maybe someone other using not macOS should investigate in that. Also I am not able to share my ssh sock with docker containers.
- [x] only run composer if composer.json exists
- [x] add install command
- [x] add update command
- [x] tests
