### PR TITLE
Fix deprecated php-coveralls reference; add language level dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "prooph"
     ],
     "require": {
+        "php": "^7.1",
         "prooph/event-store": "^7.3.1",
         "prooph/pdo-event-store": "^1.6",
         "prooph/snapshot-store": "^1.2",
@@ -31,7 +32,7 @@
         "phpunit/phpunit": "^6.0",
         "phpspec/prophecy": "^1.7",
         "prooph/php-cs-fixer-config": "^0.2.1",
-        "satooshi/php-coveralls": "^1.0",
+        "php-coveralls/php-coveralls": "^2.1",
         "malukenho/docheader": "^0.1.4"
     },
     "suggest": {


### PR DESCRIPTION
The php-coveralls requirement has moved from satooshi/php-coveralls to php-coveralls/php-coveralls. Updating this also gets rid of a warning because it was using guzzle/guzzle which is now guzzlehttp/guzzle.

I also added PHP 7.1 to Composer because PhpStorm uses this to determine the language level for showing warnings in the IDE.

I re-ran the unit tests, and all passed.